### PR TITLE
Use calibrated v2 judge prompt in eval pipeline (was still v1)

### DIFF
--- a/04_distillation/pipeline_destilacion_apolo.py
+++ b/04_distillation/pipeline_destilacion_apolo.py
@@ -34,6 +34,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 # que un TinyLlama con salida truncada/degenerada recibia 5/5 del juez sesgado.
 sys.path.insert(0, str(Path(__file__).resolve().parent / "judge_calibration"))
 from answer_guardrails import screen_answer  # noqa: E402
+from judge_prompts import get_system_prompt  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Configuracion
@@ -674,15 +675,11 @@ def train_student(output_dir: Path, experiment_name: str, config: dict):
 # ---------------------------------------------------------------------------
 # Paso 4: Evaluacion comparativa (LLM-as-Judge)
 # ---------------------------------------------------------------------------
-JUDGE_SYSTEM_PROMPT = """You are a strict evaluator. Given a question and an answer, score the answer on four dimensions.
-Return ONLY valid JSON with these exact keys:
-- accuracy_score (1-5): 1=completely incorrect, 5=fully correct
-- relevance_score (1-5): 1=off-topic, 5=directly answers all parts
-- completeness_score (1-5): 1=very incomplete, 5=fully complete
-- clarity_score (1-5): 1=very unclear, 5=very clear
-- one_sentence_summary: exactly one sentence summary
-
-Output ONLY valid JSON. No markdown. No extra text."""
+# Prompt del juez: variante ganadora de la calibracion 2026-07-24 = v2 + guardrail
+# (v2g, weighted MAE 0.524 vs 0.981 del v1 original). Se importa de judge_prompts
+# (fuente unica) para que produccion no vuelva a divergir de la version calibrada.
+# El guardrail determinista se aplica aparte en judge_response (use_guardrail=True).
+JUDGE_SYSTEM_PROMPT = get_system_prompt("v2")
 
 
 def generate_model_response(model, tokenizer, device, instruction: str, max_new: int = 256) -> str:


### PR DESCRIPTION
## What & why (plain language)

Our LLM-as-Judge calibration picked a winning setup — the **v2 prompt plus the deterministic guardrail (v2g)**. But the big evaluation pipeline (5 models × 1500 items) was still using the **old v1 judge prompt**, the biased one that caused the original "student beats teacher" artifact. The guardrail from PR #33 was already wired in, but the base prompt was never switched. So running the eval as-is would silently produce **v1+guardrail, not v2g**, and the numbers would still be partly contaminated.

This PR switches the eval pipeline's judge prompt to the calibrated v2, so the 1500-item run actually reflects the validated judge.

## Technical detail

- `04_distillation/pipeline_destilacion_apolo.py`: `JUDGE_SYSTEM_PROMPT` was an inline literal equal to v1 (sha `ad9150c7754b`). Replaced with `get_system_prompt("v2")` (sha `c1f7a24b544f`), imported from `judge_calibration/judge_prompts.py` — single source of truth, so production can no longer drift from the calibrated version.
- Guardrail unchanged: still applied in `judge_response` (`use_guardrail=True`).
- No change to the guardrail logic or the abstention handling (audited this run: the 2 `abstention_mismatch` firings match gold exactly at 1.6).

### Calibration evidence (2026-07-24, 100 items, Apolo), weighted MAE
| Variant | Prompt | Guardrail | wMAE |
|---|---|---|---|
| v2 | v2 | no | 0.981 |
| v4 | v4 | no | 1.014 |
| **v2g** | v2 | yes | **0.524** |
| v4g | v4 | yes | 0.599 |

Prompt-only edits (v3, v4) never beat v2; the guardrail is the fix and v2 is the best base → **v2g wins**.

### Tests
Full suite: **133/133 pass** (`pytest tests/`).

### Follow-up
After merge, re-run the full 5-model × 1500-item eval on this branch and report only those numbers (the v1-era eval is contaminated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)